### PR TITLE
Fix error from locally despawned other player synchronizer

### DIFF
--- a/scenes/player.tscn
+++ b/scenes/player.tscn
@@ -1569,6 +1569,7 @@ vision_area = NodePath("Hero/NetworkVisionArea3D")
 replication_interval = 0.02
 delta_interval = 0.02
 replication_config = SubResource("SceneReplicationConfig_oprun")
+public_visibility = false
 script = ExtResource("2_f1ej7")
 metadata/_custom_type_script = "uid://c5687ukdvwk4m"
 

--- a/scripts/input_controller.gd
+++ b/scripts/input_controller.gd
@@ -8,7 +8,9 @@ class_name InputController
 
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
-	set_multiplayer_authority(owner.name.to_int(), false)
+	var peer_id := owner.name.to_int()
+	set_multiplayer_authority(peer_id, false)
+	set_visibility_for(1, true)
 
 
 func _process(_delta: float) -> void:


### PR DESCRIPTION
Фикс ошибки когда другой игрок выходит за область видимости и его пешка удаляется, а его синхронизатор всё ещё пытается отправить данные и, не находя синхронизатора в локальном инстансе, кидает ошибку. Фикс заключается в установке публичной видимости синхронизатора в "false" и в _ready установка видимости синхронизатора только для сервера, т.е. он только ему будет реплицировать инпут, остальным игрокам эта информация не нужна.
<img width="711" height="90" alt="изображение" src="https://github.com/user-attachments/assets/a04ff3f6-e1a0-481f-b319-d9f85ab087d2" />