### PR TITLE
Run from editor fix

### DIFF
--- a/scripts/app.gd
+++ b/scripts/app.gd
@@ -22,7 +22,7 @@ func _ready() -> void:
 	var next_scene: PackedScene
 
 	if OS.has_feature("dedicated_server"):
-		NetworkManager.start_server()
+		NetworkManager.start_server(cmdline_arguments.get("--listen-address", "*"))
 		next_scene = dedicated_server_scene
 	else:
 		next_scene = client_scene

--- a/scripts/ui/main_menu.gd
+++ b/scripts/ui/main_menu.gd
@@ -40,6 +40,8 @@ func _on_enter_game_pressed() -> void:
 	var join_addr: Variant = App.cmdline_arguments.get("--join-address")
 	if join_addr is String:
 		NetworkManager.start_client(join_addr as String)
+	elif OS.has_feature("editor"):
+		NetworkManager.start_client("127.0.0.1")
 	else:
 		NetworkManager.start_client()
 	get_tree().change_scene_to_packed(game_scene)


### PR DESCRIPTION
Фикс регрессии отладки через редактор. Теперь при запуске игры через редактор он по умолчанию подключается к локальному серверу. Так же теперь можно указать адрес по которому прослушивать подключения на сервере, по умолчанию так же "*"